### PR TITLE
docs: add mcp-get installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,17 @@
 
 ## Installation
 
+You can install the package using either npm or mcp-get:
+
+Using npm:
 ```bash
 npx playwright install
 npm install -g @automatalabs/mcp-server-playwright
+```
+
+Using mcp-get:
+```bash
+npx @michaellatman/mcp-get@latest install @automatalabs/mcp-server-playwright
 ```
 
 ## Configuration


### PR DESCRIPTION
Add mcp-get installation instructions while preserving existing npm installation method.

- Added mcp-get install command documentation
- Preserved existing npm installation steps
- Maintained markdown formatting