### PR TITLE
Add Smithery CLI Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://www.npmjs.com/package/@automatalabs/mcp-server-playwright"><img alt="NPM Version" src="https://img.shields.io/npm/v/@automatalabs/mcp-server-playwright.svg" height="20"/></a>
   <a href="https://npmcharts.com/compare/@automatalabs/mcp-server-playwright?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/@automatalabs/mcp-server-playwright.svg" height="20"/></a>
   <a href="https://github.com/Automata-Labs-team/MCP-Server-Playwright/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/Automata-Labs-team/MCP-Server-Playwright.svg" height="20"/></a>
+  <a href="https://smithery.ai/protocol/@automatalabs/mcp-server-playwright"><img alt="Smithery Installs" src="https://smithery.ai/badge/@automatalabs/mcp-server-playwright" height="20"/></a>
 </p>
 
 ## Table of Contents
@@ -32,6 +33,15 @@
 - 🔧 JavaScript execution in browser context
 
 ## Installation
+
+### Installing via Smithery
+
+To install MCP Server Playwright for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/@automatalabs/mcp-server-playwright):
+
+```bash
+npx @smithery/cli install @automatalabs/mcp-server-playwright --client claude
+```
+
 You can install the package using either npx or mcp-get:
 
 Using npx:
@@ -162,7 +172,7 @@ Execute JavaScript in the browser console
    - Access browser console output in text format
    - Includes all console messages from the browser
 
-2. **Screenshots** (`screenshot://<name>`)
+2. **Screenshots** (`screenshot://<n>`)
    - Access PNG images of captured screenshots
    - Referenced by the name specified during capture
 


### PR DESCRIPTION
This PR adds installation instructions to automatically install MCP Server Playwright for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP. Also, it adds a badge to show the number of installations from Smithery.