### PR TITLE
Clarify Manual Configuration File Setup for Cursor Users in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,35 @@ The installation process will automatically add the following configuration to y
   }
 }
 ```
+## Using with Cursor
+
+You can also use MCP Server Playwright with [Cursor](https://www.cursor.so/), an AI-powered code editor. To enable browser automation in Cursor via MCP:
+
+1. **Install Playwright browsers** (if not already):
+    ```bash
+    npx playwright install
+    ```
+
+2. **Install MCP Server Playwright for Cursor** using Smithery:
+    ```bash
+    npx -y @smithery/cli install @automatalabs/mcp-server-playwright --client cursor
+    ```
+
+3. **Configuration file setup**:  
+   If you do not use Claude, the configuration file (`claude_desktop_config.json`) may not be created automatically.  
+   - On Windows, create a folder named `Claude` in `%APPDATA%` (usually `C:\Users\<YourName>\AppData\Roaming\Claude`).
+   - Inside that folder, create a file named `claude_desktop_config.json` with the following content:
+    ```json
+    {
+      "serverPort": 3456
+    }
+    ```
+
+4. **Follow the remaining steps in the [Installation](#installation) section above** to complete the setup.
+
+Now, you can use all the browser automation tools provided by MCP Server Playwright directly from Cursor’s AI features, such as web navigation, screenshot capture, and JavaScript execution.
+
+> **Note:** Make sure you have Node.js installed and `npx` available in your system PATH.
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ You can also use MCP Server Playwright with [Cursor](https://www.cursor.so/), an
    If you do not use Claude, the configuration file (`claude_desktop_config.json`) may not be created automatically.  
    - On Windows, create a folder named `Claude` in `%APPDATA%` (usually `C:\Users\<YourName>\AppData\Roaming\Claude`).
    - Inside that folder, create a file named `claude_desktop_config.json` with the following content:
+   
     ```json
     {
       "serverPort": 3456


### PR DESCRIPTION
This PR updates the README to provide clearer instructions for users setting up MCP Server Playwright with Cursor, specifically detailing how to manually create the claude_desktop_config.json configuration file on Windows if it is not generated automatically. This helps ensure a smoother setup process for users who do not use Claude Desktop. No code changes are included—documentation only.